### PR TITLE
Refactor storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.8.4"
+soroban-sdk = "0.9.2"
 
 [dev_dependencies]
-soroban-sdk = { version = "0.8.4", features = ["testutils"] }
+soroban-sdk = { version = "0.9.2", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -247,16 +247,6 @@ fn setup(challenge_duration: u64, bal_a: i128, bal_b: i128, mock_auth: bool) -> 
     }
 }
 
-fn verify_state(t: &Test, state: &State) {
-    assert_eq!(&t.client.get_channel(&state.channel_id).state, state);
-}
-
-fn sign_state(t: &Test, state: &State) -> (BytesN<64>, BytesN<64>) {
-    let sig_a = sign(&t.env, &t.key_alice, &state);
-    let sig_b = sign(&t.env, &t.key_bob, &state);
-    (sig_a, sig_b)
-}
-
 struct Test<'a> {
     env: Env,
     ledger_info: LedgerInfo,
@@ -274,7 +264,9 @@ struct Test<'a> {
 
 impl Test<'_> {
     fn verify_state(&self, state: &State) {
-        assert_eq!(&self.client.get_channel(&state.channel_id).state, state);
+        let c = self.client.get_channel(&state.channel_id);
+        assert!(c.is_some());
+        assert_eq!(&self.client.get_channel(&state.channel_id).unwrap().state, state);
     }
 
     fn update(&mut self, new_state: State) {


### PR DESCRIPTION
This PR gets rid rewamps the contract's storage layout.
Before this, all channels were stored in a single `Map<ChannelID, Channel>`, which was located at the `CHANNEL` symbol in instance storage. While this works, it is not efficient at all in the face of soroban's storage model.
We read and write (modify) this entire channel map sometimes multiple times in a transaction, which actually only affects one single channel. From my current understanding, this means that we need to pay fees for storing the **entire** channel map every time! This obviously scales horribly with the amount of channels managed by the contract. Conceptually, user's fees should not increase at all with the amount of channels the contract holds.

Now we instead store each channel to a **separate** enum key representing the channel id in persistent storage. This means every read or write to that channel is totally independent of (the amount of) other channels managed by the contract. 