### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perun-soroban-contract"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.8.4"
+soroban-sdk = "0.9.2"
 
 [dev_dependencies]
-soroban-sdk = { version = "0.8.4", features = ["testutils"] }
+soroban-sdk = { version = "0.9.2", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ impl Adjudicator {
         Ok(())
     }
 
-    // close gracefully closes a channel, providing a (final) signed state.
+    /// close gracefully closes a channel, providing a (final) signed state.
     pub fn close(
         env: Env,
         state: State,
@@ -325,7 +325,7 @@ impl Adjudicator {
         Ok(())
     }
 
-    /// force_close forcibly closed a channel after it has been disputed at least once and the
+    /// force_close forcibly closes a channel after it has been disputed at least once and the
     /// relative timelock (challenge_duration) has elapsed since the latest dispute.
     pub fn force_close(env: Env, channel_id: BytesN<32>) -> Result<(), Error> {
         // checks

--- a/src/test.rs
+++ b/src/test.rs
@@ -247,16 +247,6 @@ fn setup(challenge_duration: u64, bal_a: i128, bal_b: i128, mock_auth: bool) -> 
     }
 }
 
-fn verify_state(t: &Test, state: &State) {
-    assert_eq!(&t.client.get_channel(&state.channel_id).state, state);
-}
-
-fn sign_state(t: &Test, state: &State) -> (BytesN<64>, BytesN<64>) {
-    let sig_a = sign(&t.env, &t.key_alice, &state);
-    let sig_b = sign(&t.env, &t.key_bob, &state);
-    (sig_a, sig_b)
-}
-
 struct Test<'a> {
     env: Env,
     ledger_info: LedgerInfo,
@@ -274,7 +264,9 @@ struct Test<'a> {
 
 impl Test<'_> {
     fn verify_state(&self, state: &State) {
-        assert_eq!(&self.client.get_channel(&state.channel_id).state, state);
+        let c = self.client.get_channel(&state.channel_id);
+        assert!(c.is_some());
+        assert_eq!(&self.client.get_channel(&state.channel_id).unwrap().state, state);
     }
 
     fn update(&mut self, new_state: State) {


### PR DESCRIPTION
* Bump soroban-sdk version to 0.9.2
* Adjust channel storage to use individual data keys
* Change `get_channel` return type from `Result` to `Option` (in line with soroban-sdk v0.9.2 storage)